### PR TITLE
aruha-929 remove subject from the API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'org.zalando'
-version '1.1.0'
+version '2.0.0'
 
 apply plugin: 'java'
 apply plugin: 'maven'

--- a/src/main/java/org/zalando/nakadi/plugin/api/authz/AuthorizationService.java
+++ b/src/main/java/org/zalando/nakadi/plugin/api/authz/AuthorizationService.java
@@ -9,15 +9,16 @@ public interface AuthorizationService {
     }
 
     /**
-     * Check whether a caller, represented by a token, is authorized to perform an operation on a resource.
+     * Check whether a caller, represented by a token, is authorized to perform an operation on a resource. Notice that
+     * the subject is not an explicit parameter of this method call. That's because this method expects the subject to
+     * be accessible in the context, as done in org.springframework.security.core.context.SecurityContextHolder
      *
-     * @param subject The subject that performs the operation on the resource
      * @param operation the operation (read, write, admin) to authorize
      * @param resource the resource that the subject wants to perform an operation on
      * @return true if the subject, is authorized to perform the operation on the resource
      * @throws PluginException if an error occurred during execution
      */
-    boolean isAuthorized(Subject subject, Operation operation, Resource resource) throws PluginException;
+    boolean isAuthorized(Operation operation, Resource resource) throws PluginException;
 
     /**
      * Check whether an attribute is valid.

--- a/src/main/java/org/zalando/nakadi/plugin/api/authz/Subject.java
+++ b/src/main/java/org/zalando/nakadi/plugin/api/authz/Subject.java
@@ -1,9 +1,0 @@
-package org.zalando.nakadi.plugin.api.authz;
-
-public interface Subject {
-
-    String getName();
-
-    String getToken();
-
-}


### PR DESCRIPTION
[ARUHA-929: Clean up authorization code](https://techjira.zalando.net/browse/ARUHA-929)

## Description
The subject is being removed from the API since we found its interface
to be limitating and not flexible enought to cover some use cases. Also
it's more convenient to use a subject available in the execution
context and not having to carry the subject all over the code.

The concept of a Subject, an entity representing the one that is
requesting access to a given resource, remains untouched. Only the
interface no longer includes it as a parameter.

## Review
- [x] Documentation
