### PR TITLE
Make return type of getSubject() method optional

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'org.zalando'
-version '3.1.1'
+version '3.1.2'
 
 apply plugin: 'java'
 apply plugin: 'maven'

--- a/src/main/java/org/zalando/nakadi/plugin/api/authz/AuthorizationService.java
+++ b/src/main/java/org/zalando/nakadi/plugin/api/authz/AuthorizationService.java
@@ -3,6 +3,7 @@ package org.zalando.nakadi.plugin.api.authz;
 import org.zalando.nakadi.plugin.api.PluginException;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface AuthorizationService {
 
@@ -53,5 +54,5 @@ public interface AuthorizationService {
      * object.
      * @throws PluginException if an error occurred during execution
      */
-    Subject getSubject() throws PluginException;
+    Optional<Subject> getSubject() throws PluginException;
 }


### PR DESCRIPTION
[ARUHA-2122 https://jira.zalando.net/browse/ARUHA-2122)

## Description
Make `getSubject()` return type Optional as for `/heath` and `/metrics` endpoint, no `OAuth` token is required.