### PR TITLE
instance termination plugin api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'org.zalando'
-version '3.2.1'
+version '3.3.0'
 
 apply plugin: 'java'
 apply plugin: 'maven'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Mon Dec 23 14:08:03 CET 2019
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/org/zalando/nakadi/plugin/api/termination/TerminationListener.java
+++ b/src/main/java/org/zalando/nakadi/plugin/api/termination/TerminationListener.java
@@ -1,0 +1,10 @@
+package org.zalando.nakadi.plugin.api.termination;
+
+@FunctionalInterface
+public interface TerminationListener extends Runnable {
+
+    /**
+     * Listener code to be executed upon arrival of termination event.
+     */
+    void run();
+}

--- a/src/main/java/org/zalando/nakadi/plugin/api/termination/TerminationService.java
+++ b/src/main/java/org/zalando/nakadi/plugin/api/termination/TerminationService.java
@@ -23,4 +23,12 @@ public interface TerminationService {
      * @throws PluginException
      */
     void deregister(final String listenerName) throws PluginException;
+
+    /**
+     * Current status of the termination.
+     *
+     * @throws PluginException
+     */
+    boolean isTerminating() throws PluginException;
+
 }

--- a/src/main/java/org/zalando/nakadi/plugin/api/termination/TerminationService.java
+++ b/src/main/java/org/zalando/nakadi/plugin/api/termination/TerminationService.java
@@ -10,19 +10,10 @@ public interface TerminationService {
     /**
      * Registers lister to be executed once termination event happens.
      *
-     * @param listenerName        name of the listener
      * @param terminationRunnable action to execute once termination event happens
      * @throws PluginException
      */
-    void register(final String listenerName, final TerminationListener terminationRunnable) throws PluginException;
-
-    /**
-     * Removes listener by its name.
-     *
-     * @param listenerName name of the listener
-     * @throws PluginException
-     */
-    void deregister(final String listenerName) throws PluginException;
+    void register(final TerminationListener terminationRunnable) throws PluginException;
 
     /**
      * Current status of the termination.

--- a/src/main/java/org/zalando/nakadi/plugin/api/termination/TerminationService.java
+++ b/src/main/java/org/zalando/nakadi/plugin/api/termination/TerminationService.java
@@ -1,0 +1,26 @@
+package org.zalando.nakadi.plugin.api.termination;
+
+import org.zalando.nakadi.plugin.api.exceptions.PluginException;
+
+/**
+ * Termination service provides functionality to notify user about coming Nakadi instance termination.
+ */
+public interface TerminationService {
+
+    /**
+     * Registers lister to be executed once termination event happens.
+     *
+     * @param listenerName        name of the listener
+     * @param terminationRunnable action to execute once termination event happens
+     * @throws PluginException
+     */
+    void register(final String listenerName, final TerminationListener terminationRunnable) throws PluginException;
+
+    /**
+     * Removes listener by its name.
+     *
+     * @param listenerName name of the listener
+     * @throws PluginException
+     */
+    void deregister(final String listenerName) throws PluginException;
+}

--- a/src/main/java/org/zalando/nakadi/plugin/api/termination/TerminationServiceFactory.java
+++ b/src/main/java/org/zalando/nakadi/plugin/api/termination/TerminationServiceFactory.java
@@ -1,0 +1,14 @@
+package org.zalando.nakadi.plugin.api.termination;
+
+import org.zalando.nakadi.plugin.api.SystemProperties;
+import org.zalando.nakadi.plugin.api.exceptions.PluginException;
+
+public interface TerminationServiceFactory {
+
+    /**
+     * @param properties system properties to initialize plugin
+     * @return constructed ApplicationService instance
+     * @throws PluginException if an error occurred on plugin initialization
+     */
+    TerminationService init(SystemProperties properties) throws PluginException;
+}


### PR DESCRIPTION
it should be possible to notify nakadi about coming instance termination, that it can release used resources and prepare itself for termination. A good example would be subscription connection termination in clean way, that consumer will not wait commit timeout